### PR TITLE
fixed , '' and monospace

### DIFF
--- a/convtags
+++ b/convtags
@@ -1646,11 +1646,11 @@ s//]$$/g
 s//$$/g
 s//$$/g
 s//$$/g
-s//++/g
+s//`/g
 s//`/g
 s//'/g
-s//``/g
-s//''/g
+s//"/g
+s//"/g
 # Restore the [source,<language>] and [verse] patterns.
 s//[[/g
 s//]]/g


### PR DESCRIPTION
Hi,

I fixed (disabled) the following syntax that is not understandable by adoc:

"something" -> ``something''

I also replaced monospace syntax which should be different (++text++ is a link):
''monospace'' -> `monospace`